### PR TITLE
rectangle matmul with shared memory python

### DIFF
--- a/lecture5/matmul_l5.ipynb
+++ b/lecture5/matmul_l5.ipynb
@@ -375,7 +375,18 @@
    "execution_count": null,
    "id": "c421e61d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'\\n    float p = 0;\\n    for (int ph = 0; ph < ceil(w/(float)TW); ++ph) {\\n        ms[ty][tx] = ((r<w) && (ph*TW+tx)<w) ? M[ tx + ph*TW + r*w] : 0.0f;\\n        ns[ty][tx] = ((c<w) && (ph*TW+ty)<w) ? N[(ty + ph*TW)*w +c] : 0.0f;\\n        __syncthreads();\\n        for (int k = 0; k < TW; ++k) p += ms[ty][k] * ns[k][tx];\\n        __syncthreads();\\n    }\\n    if (r<w && c<w) out[r*w + c] = p;\\n'"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "\"\"\"\n",
     "    float p = 0;\n",
@@ -419,6 +430,30 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "be3963fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import threading\n",
+    "from threading import Barrier\n",
+    "\n",
+    "def run_threads(f, blockdim, *args, **kwargs):\n",
+    "    threads = []\n",
+    "    for i0 in range(blockdim.y):\n",
+    "        for i1 in range(blockdim.x):\n",
+    "            # Create a new Thread to run the function f with given arguments\n",
+    "            t = threading.Thread(target=f, args=(i0, i1, *args), kwargs=kwargs)\n",
+    "            threads.append(t)\n",
+    "            t.start()\n",
+    "\n",
+    "    # Wait for all threads to complete\n",
+    "    for t in threads:\n",
+    "        t.join()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "096fbfc1-5f01-4203-94df-98a62ddc2ee8",
    "metadata": {},
    "outputs": [],
@@ -429,19 +464,27 @@
     "\n",
     "    def get_rc(ty, tx): return blockidx.y*blockdim.y + ty, blockidx.x*blockdim.x + tx\n",
     "\n",
-    "    def fill_shared_tk(ty, tx, ph):\n",
+    "    def fill_shared_tk(ty, tx, ph, sync_barrier=None):\n",
     "        r,c = get_rc(ty, tx)\n",
     "        ms[ty*tw+tx] = m[ tx + ph*tw + r*k] if r<h and (ph*tw+tx)<k else 0.\n",
     "        ns[ty*tw+tx] = n[(ty + ph*tw)*w +c] if c<w and (ph*tw+ty)<k else 0.\n",
+    "        if sync_barrier is not None:\n",
+    "            sync_barrier.wait()\n",
     "\n",
-    "    def dotprod_tk(ty, tx):\n",
+    "    def dotprod_tk(ty, tx, sync_barrier=None):\n",
     "        r,c = get_rc(ty, tx)\n",
     "        for i in range(tw):\n",
     "            if r*w+c<len(out): out[r*w+c] += ms[ty*tw+i] * ns[tw*i+tx]\n",
+    "        if sync_barrier is not None:\n",
+    "            sync_barrier.wait()\n",
     "\n",
     "    for ph in range(int(math.ceil(k/tw))):\n",
-    "        run_threads(fill_shared_tk, blockdim, ph)\n",
-    "        run_threads(dotprod_tk, blockdim)"
+    "        # to test replace shar_sz with shar_sz+1, and it will hang\n",
+    "        # since not enough threads are synced.\n",
+    "        run_threads(fill_shared_tk, blockdim, ph, \n",
+    "                    sync_barrier=threading.Barrier(shar_sz))\n",
+    "        run_threads(dotprod_tk, blockdim,\n",
+    "                    sync_barrier=threading.Barrier(shar_sz))"
    ]
   },
   {
@@ -488,7 +531,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c5115d02-4c33-4c36-80a5-08869de7ac94",
+   "id": "e65cb4e9",
    "metadata": {},
    "outputs": [
     {

--- a/lecture5/matmul_l5.ipynb
+++ b/lecture5/matmul_l5.ipynb
@@ -152,7 +152,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dc868ac2-7e60-4a1e-8bba-b40e452b6ef9",
+   "id": "e54824bf",
    "metadata": {},
    "outputs": [
     {
@@ -373,7 +373,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12f589eb-28c1-4d67-a7a8-c85f0bf24875",
+   "id": "c421e61d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -437,7 +437,7 @@
     "    def dotprod_tk(ty, tx):\n",
     "        r,c = get_rc(ty, tx)\n",
     "        for i in range(tw):\n",
-    "            if r*w+c<len(out): out[r*w+c] += m[r*tw+i] * n[i*tw+c]\n",
+    "            if r*w+c<len(out): out[r*w+c] += ms[ty*tw+i] * ns[tw*i+tx]\n",
     "\n",
     "    for ph in range(int(math.ceil(k/tw))):\n",
     "        run_threads(fill_shared_tk, blockdim, ph)\n",
@@ -451,29 +451,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def matmul_2d(m, n):\n",
+    "def matmul_2d(m, n, tw=16):\n",
     "    h,k  = m.shape\n",
     "    k2,w = n.shape\n",
     "    assert k==k2, \"Size mismatch!\"\n",
     "    output = torch.zeros(h, w, dtype=m.dtype)\n",
-    "    tpb = ns(x=16,y=16)\n",
+    "    tpb = ns(x=tw,y=tw)\n",
     "    blocks = ns(x=math.ceil(w/tpb.x), y=math.ceil(h/tpb.y))\n",
-    "    blk_kernel2d_shar(matmul_tiled_bk, blocks, tpb, 16*16*2,\n",
+    "    blk_kernel2d_shar(matmul_tiled_bk, blocks, tpb, tw*tw*2,\n",
     "                      m.flatten(), n.flatten(), output.flatten(),\n",
-    "                      h, w, k, tw=16, mm=m)\n",
+    "                      h, w, k, tw=tw, mm=m)\n",
     "    return output"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f46d6304-aee9-4414-80f8-bb32947da2ce",
+   "id": "cb489de0",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "torch.Size([8, 784])"
+       "(torch.Size([8, 784]), torch.Size([784, 10]))"
       ]
      },
      "execution_count": null,
@@ -482,7 +482,7 @@
     }
    ],
    "source": [
-    "m1s.shape"
+    "m1s.shape, m2.shape"
    ]
   },
   {
@@ -494,7 +494,7 @@
     {
      "data": {
       "text/plain": [
-       "tensor(False)"
+       "tensor(True)"
       ]
      },
      "execution_count": null,
@@ -503,63 +503,7 @@
     }
    ],
    "source": [
-    "torch.isclose(matmul_2d(m1s, m2), m1s@m2).all()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "207fb19c-0f28-4803-b706-e5d08e8fb269",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "tensor([[185.04, 211.74, 207.05, 175.68, 184.61, 165.85, 200.46, 180.15, 159.06, 219.29],\n",
-       "        [246.11, 374.62, 354.15, 383.29, 338.41, 357.94, 128.71, 131.15, 122.34, 165.20],\n",
-       "        [249.40, 265.87, 349.05, 316.15, 296.39, 316.05, 182.69, 135.67, 161.97, 164.37],\n",
-       "        [294.56, 383.04, 415.73, 360.61, 368.37, 368.36, 209.56, 154.00, 186.31, 203.71],\n",
-       "        [329.01, 409.81, 457.99, 411.94, 386.65, 459.32, 230.68, 191.58, 222.18, 248.16],\n",
-       "        [331.02, 380.52, 393.87, 374.61, 372.91, 369.44, 196.03, 154.32, 164.01, 203.76],\n",
-       "        [322.04, 330.92, 366.76, 310.33, 362.50, 343.97, 189.47, 133.25, 189.82, 200.85],\n",
-       "        [255.43, 362.17, 379.27, 294.94, 339.76, 320.28, 164.46, 144.77, 157.93, 187.12]])"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "matmul_2d(m1s, m2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f671992a-ad9f-405c-b721-acb9d5392c21",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "tensor([[187.96, 191.44, 184.27, 196.76, 197.56, 195.40, 194.36, 192.61, 184.84, 186.31],\n",
-       "        [206.28, 205.22, 192.29, 210.71, 202.66, 204.08, 200.01, 201.26, 196.18, 199.55],\n",
-       "        [204.15, 210.09, 195.36, 206.41, 215.57, 207.06, 210.58, 207.05, 195.90, 197.03],\n",
-       "        [201.26, 203.92, 189.29, 198.65, 202.47, 198.09, 203.28, 198.94, 192.32, 193.05],\n",
-       "        [190.47, 194.77, 181.35, 190.37, 194.37, 194.06, 191.73, 191.55, 182.49, 185.08],\n",
-       "        [203.07, 205.65, 193.66, 204.50, 205.94, 199.65, 204.20, 198.63, 192.76, 200.65],\n",
-       "        [205.57, 203.16, 191.63, 209.40, 209.39, 201.50, 208.93, 201.71, 195.01, 199.23],\n",
-       "        [195.23, 198.80, 189.03, 197.50, 199.72, 199.72, 198.44, 190.80, 188.84, 197.59]])"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "m1s@m2"
+    "torch.isclose(matmul_2d(m1s, m2, tw=16), m1s@m2).all()"
    ]
   },
   {
@@ -732,9 +676,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "conda-env-modeling-py",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-modeling-py"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Shared memory 2D python rectangle matmul implementation fixes.
- Mimic CUDA `__syncthreads` with python threading.Barrier.

