### PR TITLE
dynamic-vs-static-shared-memo [Not for merge]

### DIFF
--- a/lecture5/matmul_l5.ipynb
+++ b/lecture5/matmul_l5.ipynb
@@ -2,17 +2,74 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "9d435bae-c85f-4368-8cd5-0eff0928458e",
-   "metadata": {},
+   "id": "8b2afc6a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.021544,
+     "end_time": "2024-02-11T21:36:03.448201",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:03.426657",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Setup"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "bba3631e-5016-40f4-bd46-cc91e7509f3e",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "3f86e23d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:36:03.491570Z",
+     "iopub.status.busy": "2024-02-11T21:36:03.490959Z",
+     "iopub.status.idle": "2024-02-11T21:36:17.087433Z",
+     "shell.execute_reply": "2024-02-11T21:36:17.086422Z"
+    },
+    "papermill": {
+     "duration": 13.621052,
+     "end_time": "2024-02-11T21:36:17.089781",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:03.468729",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: ninja in /opt/conda/lib/python3.10/site-packages (1.11.1.1)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install ninja"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5244268b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:36:17.133344Z",
+     "iopub.status.busy": "2024-02-11T21:36:17.132997Z",
+     "iopub.status.idle": "2024-02-11T21:36:21.307927Z",
+     "shell.execute_reply": "2024-02-11T21:36:21.307144Z"
+    },
+    "papermill": {
+     "duration": 4.199184,
+     "end_time": "2024-02-11T21:36:21.310304",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:17.111120",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import os,math,sys,torch,re,numpy as np\n",
@@ -22,9 +79,88 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "bbda41fd-dbbf-47d4-807a-67ad565b3bc8",
-   "metadata": {},
+   "execution_count": 3,
+   "id": "f10dcd1f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:36:21.353820Z",
+     "iopub.status.busy": "2024-02-11T21:36:21.353437Z",
+     "iopub.status.idle": "2024-02-11T21:36:22.548851Z",
+     "shell.execute_reply": "2024-02-11T21:36:22.547969Z"
+    },
+    "papermill": {
+     "duration": 1.219792,
+     "end_time": "2024-02-11T21:36:22.551302",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:21.331510",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import matplotlib.pyplot as plt\n",
+    "from torch.utils.cpp_extension import load_inline\n",
+    "\n",
+    "def show_img(x, figsize=(4,3), **kwargs):\n",
+    "    \"Display HW or CHW format image `x`\"\n",
+    "    plt.figure(figsize=figsize)\n",
+    "    plt.axis('off')\n",
+    "    if len(x.shape)==3: x = x.permute(1,2,0)  # CHW -> HWC\n",
+    "    plt.imshow(x.cpu(), **kwargs)\n",
+    "\n",
+    "cuda_begin = r'''\n",
+    "#include <torch/extension.h>\n",
+    "#include <stdio.h>\n",
+    "#include <c10/cuda/CUDAException.h>\n",
+    "\n",
+    "#define CHECK_CUDA(x) TORCH_CHECK(x.device().is_cuda(), #x \" must be a CUDA tensor\")\n",
+    "#define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x \" must be contiguous\")\n",
+    "#define CHECK_INPUT(x) CHECK_CUDA(x); CHECK_CONTIGUOUS(x)\n",
+    "#define CUDA_ERR(ans) { gpuAssert((ans), __FILE__, __LINE__); }\n",
+    "inline void gpuAssert(cudaError_t code, const char *file, int line, bool abort=true)\n",
+    "{\n",
+    "   if (code != cudaSuccess) \n",
+    "   {\n",
+    "      fprintf(stderr,\"GPUassert: %s %s %d\\n\", cudaGetErrorString(code), file, line);\n",
+    "      if (abort) exit(code);\n",
+    "   }\n",
+    "}\n",
+    "__host__ __device__ inline unsigned int cdiv(unsigned int a, unsigned int b) { return (a+b-1)/b;}\n",
+    "'''\n",
+    "\n",
+    "def load_cuda(cuda_src, cpp_src, funcs, opt=False, verbose=False, name=None):\n",
+    "    \"Simple wrapper for torch.utils.cpp_extension.load_inline\"\n",
+    "    if name is None: name = funcs[0]\n",
+    "    return load_inline(cuda_sources=[cuda_src], cpp_sources=[cpp_src], functions=funcs,\n",
+    "                       extra_cuda_cflags=[\"-O2\"] if opt else [], verbose=verbose, name=name)\n",
+    "\n",
+    "def cdiv(a,b):\n",
+    "    \"Int ceiling division of `a` over `b`\"\n",
+    "    return (a+b-1)//b\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "8cf986ee",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:36:22.597019Z",
+     "iopub.status.busy": "2024-02-11T21:36:22.596719Z",
+     "iopub.status.idle": "2024-02-11T21:36:22.600977Z",
+     "shell.execute_reply": "2024-02-11T21:36:22.600116Z"
+    },
+    "papermill": {
+     "duration": 0.02809,
+     "end_time": "2024-02-11T21:36:22.602891",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:22.574801",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "dim3 = namedtuple('dim3', ['x','y','z'], defaults=(1,1))"
@@ -32,9 +168,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "5b57350f-3ff6-4e10-8635-040c3736220d",
-   "metadata": {},
+   "execution_count": 5,
+   "id": "012ebbb7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:36:22.645077Z",
+     "iopub.status.busy": "2024-02-11T21:36:22.644793Z",
+     "iopub.status.idle": "2024-02-11T21:36:22.650897Z",
+     "shell.execute_reply": "2024-02-11T21:36:22.650054Z"
+    },
+    "papermill": {
+     "duration": 0.029363,
+     "end_time": "2024-02-11T21:36:22.652860",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:22.623497",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -42,7 +193,7 @@
        "dim3(x=2, y=3, z=1)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -54,9 +205,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "ca90d679-3fba-4903-8e14-7ef9efb3bf89",
-   "metadata": {},
+   "execution_count": 6,
+   "id": "97f977d9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:36:22.696634Z",
+     "iopub.status.busy": "2024-02-11T21:36:22.696005Z",
+     "iopub.status.idle": "2024-02-11T21:36:22.701263Z",
+     "shell.execute_reply": "2024-02-11T21:36:22.700457Z"
+    },
+    "papermill": {
+     "duration": 0.029246,
+     "end_time": "2024-02-11T21:36:22.703072",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:22.673826",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -64,7 +230,7 @@
        "(2, 3)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -75,9 +241,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "14e41709-f1f3-40c1-aa20-bd19737f3d86",
-   "metadata": {},
+   "execution_count": 7,
+   "id": "dacf91ec",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:36:22.745976Z",
+     "iopub.status.busy": "2024-02-11T21:36:22.745704Z",
+     "iopub.status.idle": "2024-02-11T21:36:22.749834Z",
+     "shell.execute_reply": "2024-02-11T21:36:22.749019Z"
+    },
+    "papermill": {
+     "duration": 0.027831,
+     "end_time": "2024-02-11T21:36:22.751832",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:22.724001",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "np.set_printoptions(precision=2, linewidth=140)\n",
@@ -86,9 +267,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "db47935d-8477-4116-9538-369c759322bd",
-   "metadata": {},
+   "execution_count": 8,
+   "id": "ab43f397",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:36:22.794557Z",
+     "iopub.status.busy": "2024-02-11T21:36:22.794280Z",
+     "iopub.status.idle": "2024-02-11T21:36:22.798141Z",
+     "shell.execute_reply": "2024-02-11T21:36:22.797287Z"
+    },
+    "papermill": {
+     "duration": 0.027443,
+     "end_time": "2024-02-11T21:36:22.800182",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:22.772739",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "sys.path.insert(0, '..')"
@@ -96,19 +292,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "a76aa950-6f87-452d-b048-82da11be0b24",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from utils import show_img,load_cuda,cuda_begin,cdiv"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "994f69fd-3989-46e2-ad84-71b7450f1b3f",
-   "metadata": {},
+   "execution_count": 9,
+   "id": "c6828f91",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:36:22.843042Z",
+     "iopub.status.busy": "2024-02-11T21:36:22.842781Z",
+     "iopub.status.idle": "2024-02-11T21:36:22.849692Z",
+     "shell.execute_reply": "2024-02-11T21:36:22.848865Z"
+    },
+    "papermill": {
+     "duration": 0.030866,
+     "end_time": "2024-02-11T21:36:22.851685",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:22.820819",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%load_ext wurlitzer"
@@ -116,9 +317,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "ed0d99b2-bf34-4e9c-99e5-0ebf4e4b02d7",
-   "metadata": {},
+   "execution_count": 10,
+   "id": "4cfa9019",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:36:22.894524Z",
+     "iopub.status.busy": "2024-02-11T21:36:22.894246Z",
+     "iopub.status.idle": "2024-02-11T21:36:22.903240Z",
+     "shell.execute_reply": "2024-02-11T21:36:22.902456Z"
+    },
+    "papermill": {
+     "duration": 0.032594,
+     "end_time": "2024-02-11T21:36:22.905181",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:22.872587",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# os.environ['CUDA_LAUNCH_BLOCKING']='1'\n",
@@ -127,9 +343,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "cc38ccaa-c802-46c2-962a-e1f83eba49d0",
-   "metadata": {},
+   "execution_count": 11,
+   "id": "6ca70d83",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:36:22.988876Z",
+     "iopub.status.busy": "2024-02-11T21:36:22.988157Z",
+     "iopub.status.idle": "2024-02-11T21:36:23.052694Z",
+     "shell.execute_reply": "2024-02-11T21:36:23.051962Z"
+    },
+    "papermill": {
+     "duration": 0.127136,
+     "end_time": "2024-02-11T21:36:23.054825",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:22.927689",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "m1 = torch.rand(5120, 256)\n",
@@ -140,25 +371,58 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28662938-ef33-410b-96d4-d7d503c696d6",
-   "metadata": {},
+   "id": "78b5f582",
+   "metadata": {
+    "papermill": {
+     "duration": 0.021245,
+     "end_time": "2024-02-11T21:36:23.097125",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:23.075880",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Reminder"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "0c9421c9-6cd5-479e-b3f2-7a3a8d2a7b43",
-   "metadata": {},
+   "id": "f6d57780",
+   "metadata": {
+    "papermill": {
+     "duration": 0.021482,
+     "end_time": "2024-02-11T21:36:23.140058",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:23.118576",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 2d Python kernel"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "2ef592ed-b605-46f5-b72d-662ab46a55e8",
-   "metadata": {},
+   "execution_count": 12,
+   "id": "31d3f96a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:36:23.183486Z",
+     "iopub.status.busy": "2024-02-11T21:36:23.183189Z",
+     "iopub.status.idle": "2024-02-11T21:36:23.190952Z",
+     "shell.execute_reply": "2024-02-11T21:36:23.190273Z"
+    },
+    "papermill": {
+     "duration": 0.031464,
+     "end_time": "2024-02-11T21:36:23.192848",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:23.161384",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def blk_kernel2d(f, blocks, threads, *args):\n",
@@ -170,9 +434,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "62f8923f-8072-4f52-a644-6576f7dfe352",
-   "metadata": {},
+   "execution_count": 13,
+   "id": "37d301ac",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:36:23.237223Z",
+     "iopub.status.busy": "2024-02-11T21:36:23.236930Z",
+     "iopub.status.idle": "2024-02-11T21:36:23.245205Z",
+     "shell.execute_reply": "2024-02-11T21:36:23.244346Z"
+    },
+    "papermill": {
+     "duration": 0.033457,
+     "end_time": "2024-02-11T21:36:23.247464",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:23.214007",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def matmul_bk(blockIdx, threadIdx, blockDim, m, n, out, h, w, k):\n",
@@ -187,9 +466,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "a53c2202-1169-4ac6-a477-82b82f3c5201",
-   "metadata": {},
+   "execution_count": 14,
+   "id": "5f67605e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:36:23.296312Z",
+     "iopub.status.busy": "2024-02-11T21:36:23.296029Z",
+     "iopub.status.idle": "2024-02-11T21:36:23.304713Z",
+     "shell.execute_reply": "2024-02-11T21:36:23.303935Z"
+    },
+    "papermill": {
+     "duration": 0.035363,
+     "end_time": "2024-02-11T21:36:23.306774",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:23.271411",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def matmul_2d(m, n):\n",
@@ -206,9 +500,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e54824bf",
-   "metadata": {},
+   "execution_count": 15,
+   "id": "546290e8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:36:23.357306Z",
+     "iopub.status.busy": "2024-02-11T21:36:23.356943Z",
+     "iopub.status.idle": "2024-02-11T21:36:23.547397Z",
+     "shell.execute_reply": "2024-02-11T21:36:23.546574Z"
+    },
+    "papermill": {
+     "duration": 0.218526,
+     "end_time": "2024-02-11T21:36:23.549689",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:23.331163",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -216,7 +525,7 @@
        "tensor(True)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -227,17 +536,41 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8023ed5e-6adb-4c00-b234-a80bf774baad",
-   "metadata": {},
+   "id": "4889b725",
+   "metadata": {
+    "papermill": {
+     "duration": 0.023141,
+     "end_time": "2024-02-11T21:36:23.596854",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:23.573713",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### CUDA"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "3f85d6e4-bc36-4171-b64e-3447359913e5",
-   "metadata": {},
+   "execution_count": 16,
+   "id": "a660ec7e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:36:23.645286Z",
+     "iopub.status.busy": "2024-02-11T21:36:23.644972Z",
+     "iopub.status.idle": "2024-02-11T21:36:23.653185Z",
+     "shell.execute_reply": "2024-02-11T21:36:23.652396Z"
+    },
+    "papermill": {
+     "duration": 0.035104,
+     "end_time": "2024-02-11T21:36:23.655311",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:23.620207",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "cuda_src = cuda_begin + r'''\n",
@@ -271,9 +604,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "2a82414f-bd5a-4fb1-9f7f-1f404b8d8a1f",
-   "metadata": {},
+   "execution_count": 17,
+   "id": "fbba6a93",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:36:23.701819Z",
+     "iopub.status.busy": "2024-02-11T21:36:23.701544Z",
+     "iopub.status.idle": "2024-02-11T21:36:23.708073Z",
+     "shell.execute_reply": "2024-02-11T21:36:23.707387Z"
+    },
+    "papermill": {
+     "duration": 0.031709,
+     "end_time": "2024-02-11T21:36:23.710039",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:23.678330",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "fname = 'matmul'"
@@ -281,9 +629,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d93c0b9a-2f20-460c-8393-3fb241c1ae85",
-   "metadata": {},
+   "execution_count": 18,
+   "id": "3c442c70",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:36:23.753989Z",
+     "iopub.status.busy": "2024-02-11T21:36:23.753733Z",
+     "iopub.status.idle": "2024-02-11T21:36:23.760457Z",
+     "shell.execute_reply": "2024-02-11T21:36:23.759807Z"
+    },
+    "papermill": {
+     "duration": 0.030722,
+     "end_time": "2024-02-11T21:36:23.762325",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:23.731603",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def get_sig(fname, src):\n",
@@ -293,9 +656,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "5b943b71-641c-4ec1-b336-7d04b4930c1a",
-   "metadata": {},
+   "execution_count": 19,
+   "id": "0cc18a2d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:36:23.805402Z",
+     "iopub.status.busy": "2024-02-11T21:36:23.805144Z",
+     "iopub.status.idle": "2024-02-11T21:36:23.813181Z",
+     "shell.execute_reply": "2024-02-11T21:36:23.812478Z"
+    },
+    "papermill": {
+     "duration": 0.031731,
+     "end_time": "2024-02-11T21:36:23.815093",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:23.783362",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -303,7 +681,7 @@
        "'torch::Tensor matmul(torch::Tensor m, torch::Tensor n);'"
       ]
      },
-     "execution_count": null,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -315,9 +693,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9533561e-6426-4c29-92a6-3f968521d795",
-   "metadata": {},
+   "execution_count": 20,
+   "id": "02bb1a52",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:36:23.858954Z",
+     "iopub.status.busy": "2024-02-11T21:36:23.858298Z",
+     "iopub.status.idle": "2024-02-11T21:37:31.001579Z",
+     "shell.execute_reply": "2024-02-11T21:37:31.000734Z"
+    },
+    "papermill": {
+     "duration": 67.167847,
+     "end_time": "2024-02-11T21:37:31.003899",
+     "exception": false,
+     "start_time": "2024-02-11T21:36:23.836052",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "module = load_cuda(cuda_src, cpp_src, [fname])"
@@ -325,9 +718,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "2d4e99ab-d2a7-45ef-a38f-f38ca17e22d0",
-   "metadata": {},
+   "execution_count": 21,
+   "id": "ad6b2392",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:31.047923Z",
+     "iopub.status.busy": "2024-02-11T21:37:31.047635Z",
+     "iopub.status.idle": "2024-02-11T21:37:31.204216Z",
+     "shell.execute_reply": "2024-02-11T21:37:31.203463Z"
+    },
+    "papermill": {
+     "duration": 0.180748,
+     "end_time": "2024-02-11T21:37:31.206484",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:31.025736",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "m1c,m2c = m1.contiguous().cuda(),m2.contiguous().cuda()"
@@ -335,9 +743,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "08507713-c7b5-40b4-a7c0-a9ead64f3017",
-   "metadata": {},
+   "execution_count": 22,
+   "id": "9e39c29b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:31.250535Z",
+     "iopub.status.busy": "2024-02-11T21:37:31.250201Z",
+     "iopub.status.idle": "2024-02-11T21:37:31.278159Z",
+     "shell.execute_reply": "2024-02-11T21:37:31.277469Z"
+    },
+    "papermill": {
+     "duration": 0.052143,
+     "end_time": "2024-02-11T21:37:31.280116",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:31.227973",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -345,7 +768,7 @@
        "torch.Size([5120, 5120])"
       ]
      },
-     "execution_count": null,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -356,9 +779,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "80fc299e-8c08-40f2-9c17-cc1965b0b430",
-   "metadata": {},
+   "execution_count": 23,
+   "id": "452eb4de",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:31.324756Z",
+     "iopub.status.busy": "2024-02-11T21:37:31.324493Z",
+     "iopub.status.idle": "2024-02-11T21:37:31.602613Z",
+     "shell.execute_reply": "2024-02-11T21:37:31.601800Z"
+    },
+    "papermill": {
+     "duration": 0.302656,
+     "end_time": "2024-02-11T21:37:31.604618",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:31.301962",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -366,7 +804,7 @@
        "tensor(True, device='cuda:0')"
       ]
      },
-     "execution_count": null,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -377,15 +815,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "61e2c3eb-813e-4e69-9d90-731a8bf321aa",
-   "metadata": {},
+   "execution_count": 24,
+   "id": "ffa31e18",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:31.649990Z",
+     "iopub.status.busy": "2024-02-11T21:37:31.649684Z",
+     "iopub.status.idle": "2024-02-11T21:37:33.677844Z",
+     "shell.execute_reply": "2024-02-11T21:37:33.676854Z"
+    },
+    "papermill": {
+     "duration": 2.053913,
+     "end_time": "2024-02-11T21:37:33.680392",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:31.626479",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "6.03 ms ± 234 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "28.8 ms ± 3.3 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -397,33 +850,75 @@
   },
   {
    "cell_type": "markdown",
-   "id": "836bd00e-8c17-4208-a159-aa91a00425ae",
-   "metadata": {},
+   "id": "853027e0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.021337,
+     "end_time": "2024-02-11T21:37:33.726824",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:33.705487",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "When I removed the call to the kernel itself, it took around 50 µs (0.05 ms) to run, so that's the overhead of the call on my machine."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "32b1cf32-baa7-449b-ac0b-9d787d7bc470",
-   "metadata": {},
+   "id": "0f3e7e5b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.021154,
+     "end_time": "2024-02-11T21:37:33.769317",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:33.748163",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Shared mem"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "ed2bd620-dc68-4347-9ac5-3b4335b788dc",
-   "metadata": {},
+   "id": "8982c1a2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.021243,
+     "end_time": "2024-02-11T21:37:33.812528",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:33.791285",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Python"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "0aa3d263-a704-4c67-8718-0ff5c6f5ca81",
-   "metadata": {},
+   "execution_count": 25,
+   "id": "b4fee664",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:33.856969Z",
+     "iopub.status.busy": "2024-02-11T21:37:33.856137Z",
+     "iopub.status.idle": "2024-02-11T21:37:33.863849Z",
+     "shell.execute_reply": "2024-02-11T21:37:33.863024Z"
+    },
+    "papermill": {
+     "duration": 0.031886,
+     "end_time": "2024-02-11T21:37:33.865748",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:33.833862",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "a = torch.zeros(5)\n",
@@ -432,9 +927,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "77a8ed5a-72f6-4509-8a9d-9941bfa33271",
-   "metadata": {},
+   "execution_count": 26,
+   "id": "feafb689",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:33.911485Z",
+     "iopub.status.busy": "2024-02-11T21:37:33.910841Z",
+     "iopub.status.idle": "2024-02-11T21:37:33.935828Z",
+     "shell.execute_reply": "2024-02-11T21:37:33.935037Z"
+    },
+    "papermill": {
+     "duration": 0.050051,
+     "end_time": "2024-02-11T21:37:33.938219",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:33.888168",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -442,7 +952,7 @@
        "tensor([0., 2., 0., 6., 0.])"
       ]
      },
-     "execution_count": null,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -455,9 +965,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "389a066a-216f-40eb-90d5-4723ccb42b9f",
-   "metadata": {},
+   "execution_count": 27,
+   "id": "73749170",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:33.989530Z",
+     "iopub.status.busy": "2024-02-11T21:37:33.988873Z",
+     "iopub.status.idle": "2024-02-11T21:37:33.997574Z",
+     "shell.execute_reply": "2024-02-11T21:37:33.996777Z"
+    },
+    "papermill": {
+     "duration": 0.034302,
+     "end_time": "2024-02-11T21:37:33.999575",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:33.965273",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def blk_kernel2d_shar(f, blocks, threads, sh_sz, *args, **kwargs):\n",
@@ -469,9 +994,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "ac969e7d-266d-48f6-9aa7-856ad5de92a0",
-   "metadata": {},
+   "execution_count": 28,
+   "id": "c251a610",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:34.044099Z",
+     "iopub.status.busy": "2024-02-11T21:37:34.043492Z",
+     "iopub.status.idle": "2024-02-11T21:37:34.057204Z",
+     "shell.execute_reply": "2024-02-11T21:37:34.056453Z"
+    },
+    "papermill": {
+     "duration": 0.038182,
+     "end_time": "2024-02-11T21:37:34.059282",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:34.021100",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def matmul_tiled_bk(blockIdx, blockDim, shared, m, n, out, h, w, k, tw):\n",
@@ -497,9 +1037,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "8fb0c224-5781-4e92-9b59-36a6fa39c909",
-   "metadata": {},
+   "execution_count": 29,
+   "id": "622998db",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:34.107593Z",
+     "iopub.status.busy": "2024-02-11T21:37:34.106990Z",
+     "iopub.status.idle": "2024-02-11T21:37:34.117434Z",
+     "shell.execute_reply": "2024-02-11T21:37:34.116453Z"
+    },
+    "papermill": {
+     "duration": 0.038117,
+     "end_time": "2024-02-11T21:37:34.120198",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:34.082081",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def matmul_2d(m, n, tw=16):\n",
@@ -517,9 +1072,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "7021417d-4932-46ac-838e-bbeb0fc27504",
-   "metadata": {},
+   "execution_count": 30,
+   "id": "4fc53edc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:34.164585Z",
+     "iopub.status.busy": "2024-02-11T21:37:34.164310Z",
+     "iopub.status.idle": "2024-02-11T21:37:34.172260Z",
+     "shell.execute_reply": "2024-02-11T21:37:34.171591Z"
+    },
+    "papermill": {
+     "duration": 0.031796,
+     "end_time": "2024-02-11T21:37:34.174159",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:34.142363",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -527,7 +1097,7 @@
        "(torch.Size([4, 256]), torch.Size([256, 5120]))"
       ]
      },
-     "execution_count": null,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -538,9 +1108,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "accf5bf5-0874-4a30-aeab-f01034be2a0e",
-   "metadata": {},
+   "execution_count": 31,
+   "id": "c0c13093",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:34.219919Z",
+     "iopub.status.busy": "2024-02-11T21:37:34.219643Z",
+     "iopub.status.idle": "2024-02-11T21:37:34.530635Z",
+     "shell.execute_reply": "2024-02-11T21:37:34.529772Z"
+    },
+    "papermill": {
+     "duration": 0.335648,
+     "end_time": "2024-02-11T21:37:34.532815",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:34.197167",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -548,7 +1133,7 @@
        "tensor(True)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -559,17 +1144,41 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4d1a31cf-b54f-4b8a-982f-51ff1a68bb6a",
-   "metadata": {},
+   "id": "a7698760",
+   "metadata": {
+    "papermill": {
+     "duration": 0.022493,
+     "end_time": "2024-02-11T21:37:34.577932",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:34.555439",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Python run_threads"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "6a44f65b-3ad1-4654-92b9-5b61ede1a6c4",
-   "metadata": {},
+   "execution_count": 32,
+   "id": "3b38d70d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:34.622533Z",
+     "iopub.status.busy": "2024-02-11T21:37:34.622226Z",
+     "iopub.status.idle": "2024-02-11T21:37:34.628956Z",
+     "shell.execute_reply": "2024-02-11T21:37:34.628267Z"
+    },
+    "papermill": {
+     "duration": 0.031251,
+     "end_time": "2024-02-11T21:37:34.630776",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:34.599525",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def run_threads(f, blockDim, *args, **kwargs):\n",
@@ -579,9 +1188,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "096fbfc1-5f01-4203-94df-98a62ddc2ee8",
-   "metadata": {},
+   "execution_count": 33,
+   "id": "21294376",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:34.677602Z",
+     "iopub.status.busy": "2024-02-11T21:37:34.676937Z",
+     "iopub.status.idle": "2024-02-11T21:37:34.687968Z",
+     "shell.execute_reply": "2024-02-11T21:37:34.687233Z"
+    },
+    "papermill": {
+     "duration": 0.0353,
+     "end_time": "2024-02-11T21:37:34.689854",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:34.654554",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def matmul_tiled_bk(blockIdx, blockDim, shared, m, n, out, h, w, k, tw):\n",
@@ -607,9 +1231,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d0ae141e-be1a-42cd-85aa-64be0add9e2f",
-   "metadata": {},
+   "execution_count": 34,
+   "id": "8a6f9425",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:34.734686Z",
+     "iopub.status.busy": "2024-02-11T21:37:34.734450Z",
+     "iopub.status.idle": "2024-02-11T21:37:34.742531Z",
+     "shell.execute_reply": "2024-02-11T21:37:34.741850Z"
+    },
+    "papermill": {
+     "duration": 0.032183,
+     "end_time": "2024-02-11T21:37:34.744341",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:34.712158",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def matmul_2d(m, n, tw=16):\n",
@@ -627,9 +1266,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "cb489de0",
-   "metadata": {},
+   "execution_count": 35,
+   "id": "7f62d892",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:34.788495Z",
+     "iopub.status.busy": "2024-02-11T21:37:34.788236Z",
+     "iopub.status.idle": "2024-02-11T21:37:34.796051Z",
+     "shell.execute_reply": "2024-02-11T21:37:34.795221Z"
+    },
+    "papermill": {
+     "duration": 0.031901,
+     "end_time": "2024-02-11T21:37:34.797996",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:34.766095",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -637,7 +1291,7 @@
        "(torch.Size([4, 256]), torch.Size([256, 4]))"
       ]
      },
-     "execution_count": null,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -648,9 +1302,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e65cb4e9",
-   "metadata": {},
+   "execution_count": 36,
+   "id": "ecb6f378",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:34.842232Z",
+     "iopub.status.busy": "2024-02-11T21:37:34.841997Z",
+     "iopub.status.idle": "2024-02-11T21:37:35.159286Z",
+     "shell.execute_reply": "2024-02-11T21:37:35.158236Z"
+    },
+    "papermill": {
+     "duration": 0.341746,
+     "end_time": "2024-02-11T21:37:35.161450",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:34.819704",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -658,7 +1327,7 @@
        "tensor(True)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -669,17 +1338,41 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31b204c2-e349-4afb-9787-a9a045b78977",
-   "metadata": {},
+   "id": "e331dfe4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.022024,
+     "end_time": "2024-02-11T21:37:35.206545",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:35.184521",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Python threads"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "fa6aec96-1e67-4d6d-81af-1f6c3cb6de19",
-   "metadata": {},
+   "execution_count": 37,
+   "id": "5d3b708c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:35.251763Z",
+     "iopub.status.busy": "2024-02-11T21:37:35.251382Z",
+     "iopub.status.idle": "2024-02-11T21:37:35.258240Z",
+     "shell.execute_reply": "2024-02-11T21:37:35.257538Z"
+    },
+    "papermill": {
+     "duration": 0.031764,
+     "end_time": "2024-02-11T21:37:35.260271",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:35.228507",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import threading\n",
@@ -689,9 +1382,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "28306d45-3176-4cef-95f1-5894cf494c58",
-   "metadata": {},
+   "execution_count": 38,
+   "id": "2fb47269",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:35.308351Z",
+     "iopub.status.busy": "2024-02-11T21:37:35.308083Z",
+     "iopub.status.idle": "2024-02-11T21:37:35.315227Z",
+     "shell.execute_reply": "2024-02-11T21:37:35.314444Z"
+    },
+    "papermill": {
+     "duration": 0.032811,
+     "end_time": "2024-02-11T21:37:35.317100",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:35.284289",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def g(x, sb):\n",
@@ -704,9 +1412,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "ff4e712e-5999-4e4b-a057-db65996b657d",
-   "metadata": {},
+   "execution_count": 39,
+   "id": "6deb89e4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:35.362227Z",
+     "iopub.status.busy": "2024-02-11T21:37:35.361968Z",
+     "iopub.status.idle": "2024-02-11T21:37:35.371639Z",
+     "shell.execute_reply": "2024-02-11T21:37:35.370914Z"
+    },
+    "papermill": {
+     "duration": 0.0344,
+     "end_time": "2024-02-11T21:37:35.373474",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:35.339074",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -732,9 +1455,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "bac722db-cea2-494f-9ad0-a46c010e61e2",
-   "metadata": {},
+   "execution_count": 40,
+   "id": "ba134ea0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:35.419399Z",
+     "iopub.status.busy": "2024-02-11T21:37:35.419142Z",
+     "iopub.status.idle": "2024-02-11T21:37:35.427905Z",
+     "shell.execute_reply": "2024-02-11T21:37:35.427224Z"
+    },
+    "papermill": {
+     "duration": 0.033961,
+     "end_time": "2024-02-11T21:37:35.429788",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:35.395827",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def blk_kernel2d_shar(f, blocks, tpb, sh_sz, *args, **kwargs):\n",
@@ -750,9 +1488,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "58f86730-7484-404d-b542-861a5516aa72",
-   "metadata": {},
+   "execution_count": 41,
+   "id": "a2ad12a0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:35.475358Z",
+     "iopub.status.busy": "2024-02-11T21:37:35.475096Z",
+     "iopub.status.idle": "2024-02-11T21:37:35.484728Z",
+     "shell.execute_reply": "2024-02-11T21:37:35.484052Z"
+    },
+    "papermill": {
+     "duration": 0.034174,
+     "end_time": "2024-02-11T21:37:35.486663",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:35.452489",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def matmul_tiled_bk(blockIdx, threadIdx, blockDim, shared, syncb, m, n, out, h, w, k, tw):\n",
@@ -776,9 +1529,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "f758eb6b-fc56-43e0-943f-3afd8ce86dbc",
-   "metadata": {},
+   "execution_count": 42,
+   "id": "a95148b4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:35.531981Z",
+     "iopub.status.busy": "2024-02-11T21:37:35.531534Z",
+     "iopub.status.idle": "2024-02-11T21:37:35.539457Z",
+     "shell.execute_reply": "2024-02-11T21:37:35.538850Z"
+    },
+    "papermill": {
+     "duration": 0.032676,
+     "end_time": "2024-02-11T21:37:35.541348",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:35.508672",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def matmul_2d(m, n, tw=16):\n",
@@ -796,9 +1564,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "270af122-7282-4934-833d-6fe195efc7b6",
-   "metadata": {},
+   "execution_count": 43,
+   "id": "7f929871",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:35.587389Z",
+     "iopub.status.busy": "2024-02-11T21:37:35.586918Z",
+     "iopub.status.idle": "2024-02-11T21:37:36.913749Z",
+     "shell.execute_reply": "2024-02-11T21:37:36.912735Z"
+    },
+    "papermill": {
+     "duration": 1.351882,
+     "end_time": "2024-02-11T21:37:36.915851",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:35.563969",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -806,7 +1589,7 @@
        "tensor(True)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -817,16 +1600,34 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5bfbea5-8cd1-41c0-aca8-298a48599b52",
-   "metadata": {},
+   "id": "8904ec48",
+   "metadata": {
+    "papermill": {
+     "duration": 0.030745,
+     "end_time": "2024-02-11T21:37:36.972088",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:36.941343",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### CUDA dynamic shared"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "0f42f931-580e-4ced-8735-354abe6499ef",
-   "metadata": {},
+   "id": "ef94bc7f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.022434,
+     "end_time": "2024-02-11T21:37:37.021672",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:36.999238",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Code auto-generated by ChatGPT 4, using the following prompt:\n",
     "\n",
@@ -837,9 +1638,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "97fa19f4-8ca6-4ce0-a89c-d82a79a71d09",
-   "metadata": {},
+   "execution_count": 44,
+   "id": "e9856187",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:37.067110Z",
+     "iopub.status.busy": "2024-02-11T21:37:37.066796Z",
+     "iopub.status.idle": "2024-02-11T21:37:37.073747Z",
+     "shell.execute_reply": "2024-02-11T21:37:37.073021Z"
+    },
+    "papermill": {
+     "duration": 0.031871,
+     "end_time": "2024-02-11T21:37:37.075580",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:37.043709",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "cuda_src = cuda_begin + r'''\n",
@@ -866,9 +1682,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "5ef35af0-02a5-44f1-ae3e-c05258a62bd7",
-   "metadata": {},
+   "execution_count": 45,
+   "id": "7164b30a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:37.122133Z",
+     "iopub.status.busy": "2024-02-11T21:37:37.121650Z",
+     "iopub.status.idle": "2024-02-11T21:37:37.128984Z",
+     "shell.execute_reply": "2024-02-11T21:37:37.128307Z"
+    },
+    "papermill": {
+     "duration": 0.032037,
+     "end_time": "2024-02-11T21:37:37.130803",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:37.098766",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "cuda_src += r'''\n",
@@ -901,9 +1732,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e3c81f01-589e-41f9-899a-a2050b1b4fdd",
-   "metadata": {},
+   "execution_count": 46,
+   "id": "6eb8fe63",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:37.176512Z",
+     "iopub.status.busy": "2024-02-11T21:37:37.176212Z",
+     "iopub.status.idle": "2024-02-11T21:37:37.182390Z",
+     "shell.execute_reply": "2024-02-11T21:37:37.181690Z"
+    },
+    "papermill": {
+     "duration": 0.031284,
+     "end_time": "2024-02-11T21:37:37.184242",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:37.152958",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "fname = 'matmul_dyn'"
@@ -911,9 +1757,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "eb1a24b0-0cb9-46dd-97fa-4df0bca629d6",
-   "metadata": {},
+   "execution_count": 47,
+   "id": "c495386c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:37.230869Z",
+     "iopub.status.busy": "2024-02-11T21:37:37.230193Z",
+     "iopub.status.idle": "2024-02-11T21:37:37.236988Z",
+     "shell.execute_reply": "2024-02-11T21:37:37.236228Z"
+    },
+    "papermill": {
+     "duration": 0.031625,
+     "end_time": "2024-02-11T21:37:37.238830",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:37.207205",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "cpp_src = get_sig(fname, cuda_src)"
@@ -921,19 +1782,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "7352ea50-96ca-470e-9a16-360bf09ddd75",
-   "metadata": {},
+   "execution_count": 48,
+   "id": "3ac63654",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:37:37.285625Z",
+     "iopub.status.busy": "2024-02-11T21:37:37.285148Z",
+     "iopub.status.idle": "2024-02-11T21:38:49.060794Z",
+     "shell.execute_reply": "2024-02-11T21:38:49.059775Z"
+    },
+    "papermill": {
+     "duration": 71.801646,
+     "end_time": "2024-02-11T21:38:49.063262",
+     "exception": false,
+     "start_time": "2024-02-11T21:37:37.261616",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "module = load_cuda(cuda_src, cpp_src, [fname], opt=True)"
+    "module_matmul_dyn = load_cuda(cuda_src, cpp_src, [fname], opt=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "1895e28c-8fda-403c-bd43-95a481960fbc",
-   "metadata": {},
+   "execution_count": 49,
+   "id": "48e9a29d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:38:49.110034Z",
+     "iopub.status.busy": "2024-02-11T21:38:49.109743Z",
+     "iopub.status.idle": "2024-02-11T21:38:49.177951Z",
+     "shell.execute_reply": "2024-02-11T21:38:49.177255Z"
+    },
+    "papermill": {
+     "duration": 0.093303,
+     "end_time": "2024-02-11T21:38:49.179788",
+     "exception": false,
+     "start_time": "2024-02-11T21:38:49.086485",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -941,48 +1832,87 @@
        "tensor(True, device='cuda:0')"
       ]
      },
-     "execution_count": null,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "torch.isclose(module.matmul_dyn(m1c,m2c), m1c@m2c).all()"
+    "torch.isclose(module_matmul_dyn.matmul_dyn(m1c,m2c), m1c@m2c).all()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "fc98195e-0dce-4487-9d85-aec2fdadabae",
-   "metadata": {},
+   "execution_count": 50,
+   "id": "7e8d338a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:38:49.225788Z",
+     "iopub.status.busy": "2024-02-11T21:38:49.225523Z",
+     "iopub.status.idle": "2024-02-11T21:38:51.002337Z",
+     "shell.execute_reply": "2024-02-11T21:38:51.001434Z"
+    },
+    "papermill": {
+     "duration": 1.802374,
+     "end_time": "2024-02-11T21:38:51.004501",
+     "exception": false,
+     "start_time": "2024-02-11T21:38:49.202127",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "6.56 ms ± 372 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "25.3 ms ± 2.85 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
    "source": [
     "%%timeit -n 10\n",
-    "module.matmul_dyn(m1c,m2c)\n",
+    "module_matmul_dyn.matmul_dyn(m1c,m2c)\n",
     "torch.cuda.synchronize()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "20fda413-cac6-4f4f-b362-61f6a8db4056",
-   "metadata": {},
+   "id": "7e85096a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.022207,
+     "end_time": "2024-02-11T21:38:51.049648",
+     "exception": false,
+     "start_time": "2024-02-11T21:38:51.027441",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### CUDA static shared"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d03d0811-0421-46d2-b67f-dabd7557666d",
-   "metadata": {},
+   "execution_count": 51,
+   "id": "18fd1f4a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:38:51.096013Z",
+     "iopub.status.busy": "2024-02-11T21:38:51.095711Z",
+     "iopub.status.idle": "2024-02-11T21:38:51.102869Z",
+     "shell.execute_reply": "2024-02-11T21:38:51.102163Z"
+    },
+    "papermill": {
+     "duration": 0.032641,
+     "end_time": "2024-02-11T21:38:51.104687",
+     "exception": false,
+     "start_time": "2024-02-11T21:38:51.072046",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "cuda_src = cuda_begin + r'''\n",
@@ -1021,9 +1951,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "36bea62d-90ee-41c4-8df2-aca17911ae50",
-   "metadata": {},
+   "execution_count": 52,
+   "id": "152a1153",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:38:51.150311Z",
+     "iopub.status.busy": "2024-02-11T21:38:51.150070Z",
+     "iopub.status.idle": "2024-02-11T21:39:58.508919Z",
+     "shell.execute_reply": "2024-02-11T21:39:58.507964Z"
+    },
+    "papermill": {
+     "duration": 67.408485,
+     "end_time": "2024-02-11T21:39:58.535594",
+     "exception": false,
+     "start_time": "2024-02-11T21:38:51.127109",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -1031,7 +1976,7 @@
        "tensor(True, device='cuda:0')"
       ]
      },
-     "execution_count": null,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1039,43 +1984,614 @@
    "source": [
     "fname = 'matmul_static'\n",
     "cpp_src = get_sig(fname, cuda_src)\n",
-    "module = load_cuda(cuda_src, cpp_src, [fname])\n",
-    "torch.isclose(module.matmul_static(m1c,m2c), m1c@m2c).all()"
+    "matmul_static = load_cuda(cuda_src, cpp_src, [fname])\n",
+    "torch.isclose(matmul_static.matmul_static(m1c,m2c), m1c@m2c).all()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "f0ab2501-a73a-48d3-9ee5-0c1e508e1fe4",
-   "metadata": {},
+   "execution_count": 53,
+   "id": "45bc0d1d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:39:58.585166Z",
+     "iopub.status.busy": "2024-02-11T21:39:58.584889Z",
+     "iopub.status.idle": "2024-02-11T21:40:00.023324Z",
+     "shell.execute_reply": "2024-02-11T21:40:00.022384Z"
+    },
+    "papermill": {
+     "duration": 1.465092,
+     "end_time": "2024-02-11T21:40:00.025372",
+     "exception": false,
+     "start_time": "2024-02-11T21:39:58.560280",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "4.52 ms ± 253 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "20.4 ms ± 3.5 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
    "source": [
     "%%timeit -n 10\n",
-    "module.matmul_static(m1c,m2c)\n",
+    "matmul_static.matmul_static(m1c,m2c)\n",
     "torch.cuda.synchronize()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "fe5ab0d1-f574-42e1-9d50-e9ffdcd50861",
-   "metadata": {},
+   "id": "9c184ebe",
+   "metadata": {
+    "papermill": {
+     "duration": 0.022564,
+     "end_time": "2024-02-11T21:40:00.071219",
+     "exception": false,
+     "start_time": "2024-02-11T21:40:00.048655",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Static shared with linear index"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a755072b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.023058,
+     "end_time": "2024-02-11T21:40:00.116928",
+     "exception": false,
+     "start_time": "2024-02-11T21:40:00.093870",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "The code is modified from the dynamic shared memory.\n",
+    "* Change from `extern __shared__ float ms[];` to `__shared__ float ms[16*16*2];`\n",
+    "* Change from \n",
+    "```    \n",
+    "matmul_k<<<blocks,tpb,size>>>(\n",
+    "m.data_ptr<float>(), n.data_ptr<float>(), output.data_ptr<float>(), h, w, k, TW);\n",
+    "```\n",
+    "to \n",
+    "```\n",
+    "matmul_k<<<blocks,tpb>>>(\n",
+    "m.data_ptr<float>(), n.data_ptr<float>(), output.data_ptr<float>(), h, w, k, TW);\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "957ba783",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:40:00.163732Z",
+     "iopub.status.busy": "2024-02-11T21:40:00.163084Z",
+     "iopub.status.idle": "2024-02-11T21:40:00.170334Z",
+     "shell.execute_reply": "2024-02-11T21:40:00.169670Z"
+    },
+    "papermill": {
+     "duration": 0.032781,
+     "end_time": "2024-02-11T21:40:00.172261",
+     "exception": false,
+     "start_time": "2024-02-11T21:40:00.139480",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cuda_src = cuda_begin + r'''\n",
+    "__global__ void matmul_k(float *m, float *n, float *out, int h, int w, int k, int tw) {\n",
+    "    int tc=threadIdx.x, tr=threadIdx.y;\n",
+    "    int r=blockIdx.y*blockDim.y+tr, c=blockIdx.x*blockDim.x+tc;\n",
+    "\n",
+    "    __shared__ float ms[16*16*2];\n",
+    "    float *ns = &ms[tw*tw];\n",
+    "\n",
+    "    float p = 0.0f;\n",
+    "    for (int ph = 0; ph < cdiv(k,tw); ++ph) {\n",
+    "        int idx = ph*tw;\n",
+    "        ms[tr*tw + tc] = r<h && idx+tc<k ? m[ tc+idx + r*k ] : 0.0f;\n",
+    "        ns[tr*tw + tc] = c<w && idx+tr<k ? n[(tr+idx)*w + c] : 0.0f;\n",
+    "        __syncthreads();\n",
+    "        for (int i=0; i<tw; ++i) p += ms[tr*tw + i] * ns[tw*i + tc];\n",
+    "        __syncthreads();\n",
+    "    }\n",
+    "    if (r<h && c<w) out[r*w + c] = p;\n",
+    "}\n",
+    "'''"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "0d967cf7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:40:00.218560Z",
+     "iopub.status.busy": "2024-02-11T21:40:00.218067Z",
+     "iopub.status.idle": "2024-02-11T21:40:00.224881Z",
+     "shell.execute_reply": "2024-02-11T21:40:00.224179Z"
+    },
+    "papermill": {
+     "duration": 0.031895,
+     "end_time": "2024-02-11T21:40:00.226673",
+     "exception": false,
+     "start_time": "2024-02-11T21:40:00.194778",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cuda_src += r'''\n",
+    "torch::Tensor matmul_dyn_modified(torch::Tensor m, torch::Tensor n) {\n",
+    "    CHECK_INPUT(m); CHECK_INPUT(n);\n",
+    "    int h=m.size(0), w=n.size(1), k=m.size(1);\n",
+    "    TORCH_CHECK(k==n.size(0), \"Size mismatch!\");\n",
+    "    auto output = torch::zeros({h, w}, m.options());\n",
+    "\n",
+    "    /*\n",
+    "    cudaDeviceProp devProp;\n",
+    "    CUDA_ERR(cudaGetDeviceProperties(&devProp, 0));\n",
+    "    int maxThreads = devProp.maxThreadsPerBlock;\n",
+    "    size_t requiredSize = static_cast<size_t>(maxThreads) * 2 * sizeof(float);\n",
+    "    size_t size = min(devProp.sharedMemPerBlock, requiredSize);\n",
+    "    int TW = std::sqrt(maxThreads);\n",
+    "    */\n",
+    "    int TW = 16;\n",
+    "    size_t size = TW*TW * 2 * sizeof(float);\n",
+    "\n",
+    "    dim3 tpb(TW,TW);\n",
+    "    dim3 blocks(cdiv(w, tpb.x), cdiv(h, tpb.y));\n",
+    "    matmul_k<<<blocks,tpb>>>(\n",
+    "        m.data_ptr<float>(), n.data_ptr<float>(), output.data_ptr<float>(), h, w, k, TW);\n",
+    "    C10_CUDA_KERNEL_LAUNCH_CHECK();\n",
+    "    return output;\n",
+    "}\n",
+    "'''"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "id": "3d4c67e2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:40:00.273628Z",
+     "iopub.status.busy": "2024-02-11T21:40:00.273347Z",
+     "iopub.status.idle": "2024-02-11T21:41:07.664475Z",
+     "shell.execute_reply": "2024-02-11T21:41:07.663624Z"
+    },
+    "papermill": {
+     "duration": 67.439437,
+     "end_time": "2024-02-11T21:41:07.688939",
+     "exception": false,
+     "start_time": "2024-02-11T21:40:00.249502",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor(True, device='cuda:0')"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fname = 'matmul_dyn_modified'\n",
+    "cpp_src = get_sig(fname, cuda_src)\n",
+    "module_matmul_dyn_modified = load_cuda(cuda_src, cpp_src, [fname])\n",
+    "torch.isclose(module_matmul_dyn_modified.matmul_dyn_modified(m1c,m2c), m1c@m2c).all()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "a5df5ee1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:41:07.739144Z",
+     "iopub.status.busy": "2024-02-11T21:41:07.738801Z",
+     "iopub.status.idle": "2024-02-11T21:41:09.551439Z",
+     "shell.execute_reply": "2024-02-11T21:41:09.550527Z"
+    },
+    "papermill": {
+     "duration": 1.841615,
+     "end_time": "2024-02-11T21:41:09.553507",
+     "exception": false,
+     "start_time": "2024-02-11T21:41:07.711892",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "25.8 ms ± 3.03 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -n 10\n",
+    "module_matmul_dyn_modified.matmul_dyn_modified(m1c,m2c)\n",
+    "torch.cuda.synchronize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63f0e7a7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.022588,
+     "end_time": "2024-02-11T21:41:09.599478",
+     "exception": false,
+     "start_time": "2024-02-11T21:41:09.576890",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Experiment Three Variants"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69d8eadc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.022383,
+     "end_time": "2024-02-11T21:41:09.644589",
+     "exception": false,
+     "start_time": "2024-02-11T21:41:09.622206",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "id": "c93a192d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:41:09.691625Z",
+     "iopub.status.busy": "2024-02-11T21:41:09.691005Z",
+     "iopub.status.idle": "2024-02-11T21:41:09.722956Z",
+     "shell.execute_reply": "2024-02-11T21:41:09.722095Z"
+    },
+    "papermill": {
+     "duration": 0.05769,
+     "end_time": "2024-02-11T21:41:09.724975",
+     "exception": false,
+     "start_time": "2024-02-11T21:41:09.667285",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "m1 = torch.rand(5120, 256)\n",
+    "m2 = torch.rand(256, 5120)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "id": "4ba8e30e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:41:09.771508Z",
+     "iopub.status.busy": "2024-02-11T21:41:09.771198Z",
+     "iopub.status.idle": "2024-02-11T21:41:09.784788Z",
+     "shell.execute_reply": "2024-02-11T21:41:09.783960Z"
+    },
+    "papermill": {
+     "duration": 0.039067,
+     "end_time": "2024-02-11T21:41:09.786764",
+     "exception": false,
+     "start_time": "2024-02-11T21:41:09.747697",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "m1c,m2c = m1.clone().contiguous().cuda(),m2.clone().contiguous().cuda()  ## always make a copy for the input of matmul function"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c8429e0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.022489,
+     "end_time": "2024-02-11T21:41:09.832570",
+     "exception": false,
+     "start_time": "2024-02-11T21:41:09.810081",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Dynamic shared memory"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2797820",
+   "metadata": {
+    "papermill": {
+     "duration": 0.022422,
+     "end_time": "2024-02-11T21:41:09.877649",
+     "exception": false,
+     "start_time": "2024-02-11T21:41:09.855227",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "id": "0876bafe",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:41:09.924783Z",
+     "iopub.status.busy": "2024-02-11T21:41:09.924079Z",
+     "iopub.status.idle": "2024-02-11T21:41:11.645469Z",
+     "shell.execute_reply": "2024-02-11T21:41:11.644661Z"
+    },
+    "papermill": {
+     "duration": 1.747264,
+     "end_time": "2024-02-11T21:41:11.647504",
+     "exception": false,
+     "start_time": "2024-02-11T21:41:09.900240",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "24.5 ms ± 772 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -n 10\n",
+    "module_matmul_dyn.matmul_dyn(m1c,m2c)\n",
+    "torch.cuda.synchronize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b5ce04a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.022874,
+     "end_time": "2024-02-11T21:41:11.694033",
+     "exception": false,
+     "start_time": "2024-02-11T21:41:11.671159",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Static shared memory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "id": "955ed7da",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:41:11.741292Z",
+     "iopub.status.busy": "2024-02-11T21:41:11.740988Z",
+     "iopub.status.idle": "2024-02-11T21:41:11.751038Z",
+     "shell.execute_reply": "2024-02-11T21:41:11.750164Z"
+    },
+    "papermill": {
+     "duration": 0.037773,
+     "end_time": "2024-02-11T21:41:11.754979",
+     "exception": false,
+     "start_time": "2024-02-11T21:41:11.717206",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "m1c,m2c = m1.clone().contiguous().cuda(),m2.clone().contiguous().cuda()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "664c4f89",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:41:11.801999Z",
+     "iopub.status.busy": "2024-02-11T21:41:11.801713Z",
+     "iopub.status.idle": "2024-02-11T21:41:13.148080Z",
+     "shell.execute_reply": "2024-02-11T21:41:13.147204Z"
+    },
+    "papermill": {
+     "duration": 1.372048,
+     "end_time": "2024-02-11T21:41:13.150179",
+     "exception": false,
+     "start_time": "2024-02-11T21:41:11.778131",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "19.1 ms ± 676 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -n 10\n",
+    "matmul_static.matmul_static(m1c,m2c)\n",
+    "torch.cuda.synchronize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94303109",
+   "metadata": {
+    "papermill": {
+     "duration": 0.023593,
+     "end_time": "2024-02-11T21:41:13.197772",
+     "exception": false,
+     "start_time": "2024-02-11T21:41:13.174179",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Static shared memory with linear index [simple change from dynamic shared memory code]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "f739d4a3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:41:13.245537Z",
+     "iopub.status.busy": "2024-02-11T21:41:13.245190Z",
+     "iopub.status.idle": "2024-02-11T21:41:13.261404Z",
+     "shell.execute_reply": "2024-02-11T21:41:13.260528Z"
+    },
+    "papermill": {
+     "duration": 0.042904,
+     "end_time": "2024-02-11T21:41:13.263544",
+     "exception": false,
+     "start_time": "2024-02-11T21:41:13.220640",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "m1c,m2c = m1.clone().contiguous().cuda(),m2.clone().contiguous().cuda()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "id": "d836b2b3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:41:13.314289Z",
+     "iopub.status.busy": "2024-02-11T21:41:13.313661Z",
+     "iopub.status.idle": "2024-02-11T21:41:15.038749Z",
+     "shell.execute_reply": "2024-02-11T21:41:15.037952Z"
+    },
+    "papermill": {
+     "duration": 1.751672,
+     "end_time": "2024-02-11T21:41:15.040805",
+     "exception": false,
+     "start_time": "2024-02-11T21:41:13.289133",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "24.5 ms ± 742 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -n 10\n",
+    "module_matmul_dyn_modified.matmul_dyn_modified(m1c,m2c)\n",
+    "torch.cuda.synchronize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16d8554c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.022787,
+     "end_time": "2024-02-11T21:41:15.087250",
+     "exception": false,
+     "start_time": "2024-02-11T21:41:15.064463",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "83649442",
+   "metadata": {
+    "papermill": {
+     "duration": 0.022646,
+     "end_time": "2024-02-11T21:41:15.132897",
+     "exception": false,
+     "start_time": "2024-02-11T21:41:15.110251",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Numba"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "99d0a300-2763-4b9d-a496-eb3c877c006b",
-   "metadata": {},
+   "execution_count": 65,
+   "id": "fc03e3ab",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:41:15.181090Z",
+     "iopub.status.busy": "2024-02-11T21:41:15.180340Z",
+     "iopub.status.idle": "2024-02-11T21:41:15.915827Z",
+     "shell.execute_reply": "2024-02-11T21:41:15.915038Z"
+    },
+    "papermill": {
+     "duration": 0.761694,
+     "end_time": "2024-02-11T21:41:15.918033",
+     "exception": false,
+     "start_time": "2024-02-11T21:41:15.156339",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from numba import cuda\n",
@@ -1084,9 +2600,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "b409312b-1dca-4e63-995d-9b519b61b58f",
-   "metadata": {},
+   "execution_count": 66,
+   "id": "6a5142cc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:41:15.965816Z",
+     "iopub.status.busy": "2024-02-11T21:41:15.965542Z",
+     "iopub.status.idle": "2024-02-11T21:41:15.977443Z",
+     "shell.execute_reply": "2024-02-11T21:41:15.976598Z"
+    },
+    "papermill": {
+     "duration": 0.037797,
+     "end_time": "2024-02-11T21:41:15.979401",
+     "exception": false,
+     "start_time": "2024-02-11T21:41:15.941604",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "@cuda.jit\n",
@@ -1113,9 +2644,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "223cdf11-1d26-44db-8c9b-aaac3607f6b3",
-   "metadata": {},
+   "execution_count": 67,
+   "id": "a0246e0f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:41:16.028819Z",
+     "iopub.status.busy": "2024-02-11T21:41:16.028541Z",
+     "iopub.status.idle": "2024-02-11T21:41:16.036803Z",
+     "shell.execute_reply": "2024-02-11T21:41:16.036083Z"
+    },
+    "papermill": {
+     "duration": 0.034262,
+     "end_time": "2024-02-11T21:41:16.038636",
+     "exception": false,
+     "start_time": "2024-02-11T21:41:16.004374",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def matmul_2d_numba(m, n, tw=16):\n",
@@ -1132,9 +2678,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "4a09a6c3-e161-4ad1-ad50-c8020847b220",
-   "metadata": {},
+   "execution_count": 68,
+   "id": "cf35369d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:41:16.085919Z",
+     "iopub.status.busy": "2024-02-11T21:41:16.085631Z",
+     "iopub.status.idle": "2024-02-11T21:41:17.348187Z",
+     "shell.execute_reply": "2024-02-11T21:41:17.347388Z"
+    },
+    "papermill": {
+     "duration": 1.288296,
+     "end_time": "2024-02-11T21:41:17.350211",
+     "exception": false,
+     "start_time": "2024-02-11T21:41:16.061915",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -1142,7 +2703,7 @@
        "tensor(True, device='cuda:0')"
       ]
      },
-     "execution_count": null,
+     "execution_count": 68,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1153,15 +2714,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d50ac1f7-0a23-4aed-9f45-0cd6db294825",
-   "metadata": {},
+   "execution_count": 69,
+   "id": "c84754ec",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-11T21:41:17.400951Z",
+     "iopub.status.busy": "2024-02-11T21:41:17.400343Z",
+     "iopub.status.idle": "2024-02-11T21:41:21.394708Z",
+     "shell.execute_reply": "2024-02-11T21:41:21.393752Z"
+    },
+    "papermill": {
+     "duration": 4.021111,
+     "end_time": "2024-02-11T21:41:21.396693",
+     "exception": false,
+     "start_time": "2024-02-11T21:41:17.375582",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "16.2 ms ± 343 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "56.9 ms ± 1.79 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -1174,17 +2750,59 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35fe0c4a-1990-4b07-8c37-c7d44277d1e2",
-   "metadata": {},
+   "id": "79866788",
+   "metadata": {
+    "papermill": {
+     "duration": 0.025316,
+     "end_time": "2024-02-11T21:41:21.447192",
+     "exception": false,
+     "start_time": "2024-02-11T21:41:21.421876",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": []
   }
  ],
  "metadata": {
+  "kaggle": {
+   "accelerator": "nvidiaTeslaT4",
+   "dataSources": [],
+   "dockerImageVersionId": 30646,
+   "isGpuEnabled": true,
+   "isInternetEnabled": true,
+   "language": "python",
+   "sourceType": "notebook"
+  },
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 322.400375,
+   "end_time": "2024-02-11T21:41:22.893671",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "__notebook__.ipynb",
+   "output_path": "__notebook__.ipynb",
+   "parameters": {},
+   "start_time": "2024-02-11T21:36:00.493296",
+   "version": "2.5.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This is to investigate the execution time difference between the dynamic vs static shared memory.
If we use the **linear index for shared memory** (instead of the 2d index), the execution time is indeed the **same**.

Just made a few changes from the original dynamic shared memory implementation and obtained a "copy" of the same implementation with static shared memory (linear index form).

Three forms are benchmarked in the T4 GPU below.  Dynamic shared mem has the same runtime as the static shared memo with linear index.

![image](https://github.com/cuda-mode/lectures/assets/7495155/3f603490-f325-409d-8311-698e53d96b8a)

The full notebook can be previewed in this PR or [from Kaggle notebook](https://www.kaggle.com/code/lancerts/cuda-mode-session-5)

cc @jph00 
