### PR TITLE
include the cmd to enable interpret mode

### DIFF
--- a/lecture1/triton_square.py
+++ b/lecture1/triton_square.py
@@ -3,6 +3,10 @@ import triton
 import triton.language as tl
 import torch
 
+# if @triton.jit(interpret=True) does not work, please use the following two lines to enable interpret mode
+# import os
+# os.environ["TRITON_INTERPRET"] = "1"
+
 @triton.jit
 def square_kernel(output_ptr, input_ptr, input_row_stride, output_row_stride, n_cols, BLOCK_SIZE: tl.constexpr):
     # The rows of the softmax are independent, so we parallelize across those


### PR DESCRIPTION
`@triton.jit(interpret=True)` may not work (and it doesnt work for my run), see the issue reported [here](https://github.com/openai/triton/issues/2983).

Tested the following locally and it works fine, added as comments in the code
```
import os
os.environ["TRITON_INTERPRET"] = "1"
```

@msaroufim 