### PR TITLE
Fix some comments in `leture009/segment_reduce.cu`

### DIFF
--- a/lecture_009/segment_reduce.cu
+++ b/lecture_009/segment_reduce.cu
@@ -5,8 +5,8 @@
 
 __global__ void SharedMemoryReduction(float* input, float* output, int n) {
     __shared__ float input_s[BLOCK_DIM]; 
-    unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x; // index within a block
-    unsigned int t = threadIdx.x; // global index
+    unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x; // global index
+    unsigned int t = threadIdx.x; // index within a block
 
     // Load elements into shared memory
     if (idx < n) {


### PR DESCRIPTION
Correct the comments of variables `idx` and `t`.