### PR TITLE
Add lecture 103 layout algebra slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,5 +236,5 @@ Speaker: Vicki Wang
 - [Slides](lecture_086)
 
 ## Lecture 103: Fundamentals of CuTe Layout Algebra and Category-theoretic Interpretation
-Speaker: Colfax Research: Jack Carlisle, Jay Shah, Reuben Stern, Paul VanKoughnett
+Speaker: Jack Carlisle and Jay Shah
 - [Slides](lecture_103)

--- a/README.md
+++ b/README.md
@@ -234,3 +234,7 @@ Speaker: Paulius Micikevicius
 ## Lecture 86: Introduction to CuTeDSL (for NVIDIA competition)
 Speaker: Vicki Wang
 - [Slides](lecture_086)
+
+## Lecture 103: Fundamentals of CuTe Layout Algebra and Category-theoretic Interpretation
+Speaker: Colfax Research: Jack Carlisle, Jay Shah, Reuben Stern, Paul VanKoughnett
+- [Slides](lecture_103)


### PR DESCRIPTION
## Summary
- add the layout algebra PDF under `lecture_103/`
- add Lecture 103 to the root README

## Testing
- verified the PDF is present in `lecture_103/`
- verified the README link entry was added